### PR TITLE
Mitigate 'accept-license' failure on upgrade

### DIFF
--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -51,7 +51,7 @@ end
 
 if node['splunk']['accept_license']
   execute "#{splunk_cmd} enable boot-start --accept-license --answer-yes" do
-    not_if "grep -q -- '--no-prompt --answer-yes' /etc/init.d/splunk"
+    only_if { File.exist?("#{splunk_dir}/ftr") }
   end
 end
 


### PR DESCRIPTION
### Version:
* chef-splunk 1.3.0
* splunkforwarder-6.1.0-206881-linux-2.6-amd64 (Ubuntu)
* splunkforwarder-6.1.3-220630-linux-2.6-amd64 (Ubuntu)

### Environment:
Ubuntu 14.04

### Scenario:
As reported by ampledata in issue #23, current Splunk forwarder / client upgrade operations seem to be failing due to the the license "not being accepted". This seems to be happening even with the "accept_license" attribute set to True.

### Steps to Reproduce:
1. Perform an installation of an older Splunk forwarder (chef-splunk < 1.3.0)
2. Update the cookbook (chef-splunk = 1.3.0)
3. Attempt an upgrade via chef-splunk::client with the "accept_license" set to True in your attributes.

### Expected Result:
Splunk forwarder / client being upgraded with the license accepted automatically on start / restart of the Splunk daemon.

### Actual Result:
An error will be raised on the 'service' call towards the end of the run. The new version will be installed, but it will not run without the license being accepted manually.

### Proposed Resolution:
In order to prevent this error I've changed the 'boot-start' check to verify whether the Splunk 'First Time Run' (ftr) exists in the Splunk Home. This file is created on both installation and upgrade operations - at least in the case of 6.1.0 to 6.1.3 - and is subsequently removed at the first successful startup of the Splunk client.

I've tested this against both a fresh install as well as an upgrade from Splunk Forwarder 6.1.0 to Splunk Forwarder 6.1.3 on Ubuntu 14.04 without any issues. Assuming this doesn't break any existing functionality that I've missed as part of the last commit to this recipe, is this commit acceptable to rectify this issue? :)

Cheers,
Peter