### PR TITLE
initial support for splunk universal client running as a server

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ General attributes:
 * `node['splunk']['web_port']`: The port that the splunkweb service
   listens to. This is set to the default for HTTPS, 443, as it is
   configured by the `setup_ssl` recipe.
+* `node['splunk']['ratelimit_kilobytessec']`: The default splunk rate limiting rate can now easily be changed with an attribute.  Default is 2048KBytes/sec.
 
 The two URL attributes below are selected by platform and architecture
 by default.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,6 +19,7 @@ default['splunk']['accept_license'] = false
 default['splunk']['is_server']      = false
 default['splunk']['receiver_port']  = '9997'
 default['splunk']['web_port']       = '443'
+default['splunk']['ratelimit_kilobytessec'] = '2048'
 
 default['splunk']['user'] = {
   'username' => 'splunk',

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -30,8 +30,20 @@ end
 
 def splunk_dir
   # Splunk Enterprise (Server) will install in /opt/splunk.
-  # Splunk Universal Forwarder (not Server) will install in /opt/splunkforwarder
-  node['splunk']['is_server'] ? '/opt/splunk' : '/opt/splunkforwarder'
+  # Splunk Universal Forwarder can be a used as a client or a forwarding
+  # (intermediary) server which installs to /opt/splunkforwarder
+  forwarderpath = '/opt/splunkforwarder'
+  enterprisepath = '/opt/splunk'
+  if node['splunk']['is_intermediate'] == true
+    path = forwarderpath
+    return path
+  elsif node['splunk']['is_server'] == true
+    path = enterprisepath
+    return path
+  else
+    path = forwarderpath
+    return path
+  end
 end
 
 def splunk_auth(auth)

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -64,7 +64,7 @@ end
 template "#{splunk_dir}/etc/apps/SplunkUniversalForwarder/default/limits.conf" do
   source 'limits.conf.erb'
   mode 0644
-  variables :ratelimit_kbps => node['splunk']['client']['ratelimit_kilobytessec']
+  variables :ratelimit_kbps => node['splunk']['ratelimit_kilobytessec']
   notifies :restart, 'service[splunk]'
 end
 

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -61,5 +61,12 @@ template "#{splunk_dir}/etc/system/local/inputs.conf" do
   not_if { node['splunk']['inputs_conf'].nil? || node['splunk']['inputs_conf']['host'].empty? }
 end
 
+template "#{splunk_dir}/etc/apps/SplunkUniversalForwarder/default/limits.conf" do
+  source 'limits.conf.erb'
+  mode 0644
+  variables :ratelimit_kbps => node['splunk']['client']['ratelimit_kilobytessec']
+  notifies :restart, 'service[splunk]'
+end
+
 include_recipe 'chef-splunk::service'
 include_recipe 'chef-splunk::setup_auth'

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -72,7 +72,7 @@ ruby_block "splunk_fix_file_ownership" do
       end
     end
   end
-  not_if node['splunk']['server']['runasroot']
+  not_if { node['splunk']['server']['runasroot'] }
 end
 
 template '/etc/init.d/splunk' do

--- a/templates/default/limits.conf.erb
+++ b/templates/default/limits.conf.erb
@@ -1,0 +1,3 @@
+# Dropped off by Chef
+[thruput]
+maxKBps = <%= @ratelimit_kbps %>


### PR DESCRIPTION
Had to modify the splunk_dir definition in libraries/helpers.rb so that if a node['splunk']['is_intermediate']  attribute is found it can override node['splunk']['is_server'] when it comes to setting the splunk_dir.

splunk_fix_file_ownership was previously a definition which seemed clean and tidy, however root-owned files get created as part of using a universal forwarder, files which if you run as a the 'splunk' user you cannot read, and also files that don't exist during the compile phase of a chef run.  This change switches from a definition to just a plain ruby_block that runs during execution phase.  I think its a little bit uglier, but the behavior is better than before (we do not want this to run during compile phase, it needs to be execution phase).

Also learned about the "#{splunk_dir}/ftr" file ("first time run") and it made sense to change behavior around license acceptance to be the first time run instead of "before /etc/init.d/splunk is replaced with a template".